### PR TITLE
Add percentage based attachment preview quality

### DIFF
--- a/lib/layouts/settings/attachment_panel.dart
+++ b/lib/layouts/settings/attachment_panel.dart
@@ -131,6 +131,7 @@ class _AttachmentPanelState extends State<AttachmentPanel> {
                       update: (double val) {
                         _settingsCopy.previewCompressionQuality = val.toInt();
                       },
+                      formatValue: ((double val) => val.toInt().toString() + "%"),
                       min: 10,
                       max: 100,
                       divisions: 9),


### PR DESCRIPTION
Fixes #894.

Changes preview quality display from "25.0" to "25%".